### PR TITLE
Update shared-password admin instructions

### DIFF
--- a/password-access.qmd
+++ b/password-access.qmd
@@ -6,40 +6,46 @@ This page is written primarily for workshop leads (mentors and other partners) w
 
 ## Using the Openscapes 2i2c Hub in a workshop using a shared password
 
+### Instructions for workshop leads
+
 If you are hosting a workshop that has a large number of participants, especially
 if workflows with GitHub are not part of the teaching curriculum, use the "shared password" 
 access. This access method allows the instructors to share a single password
 with learners at the start of the workshop which they can use to log on the the 
 Hub. Note that while this access method is nicely streamlined for workshop leads 
 and participants, Hub admins do not have any way to contact the people added to 
-the Hub. Thus, participants with this method are only allowed to stay in the Hub f
-or one week before being removed.
+the Hub. Thus, participants with this method are only allowed to stay in the Hub
+for one week before being removed.
 
-- Check with the [primary contact for your hub](about.qmd#primary-contacts) to 
+- Check with the [primary contact/admin for your hub](about.qmd#primary-contacts) to 
   ensure that the Hub image has the packages you need
 - Reach out to 2i2c _a month in advance_ via an email to `support at 2i2c.freshdesk.com` 
-  (example below) to tell them about the workshop date, start and end times, 
+  (example below), cc-ing the primary contacts for your hub, to tell them about the workshop date, start and end times, 
   \# of participants, and anticipated level of resources to be used. Also tell
   them that you would like to use the shared password hub, and provide a desired 
   password.
+- *Do not* ask your workshop particants to request access via the access request Google form - it is not necessary for these types of workshops.
 
 ::: {.callout-tip collapse="true"}
 ## Example email to 2i2c for a workshop with shared password authentication
+
+*To: support [at] 2i2c.freshdesk.com*
+*cc: Openscapes/NASA/NOAA [primary contact](about.qmd#primary-contacts)*
 
 Hello,
 
 The LP DAAC and Openscapes have an upcoming event where we are planning to use 
 the Openscapes Hub. Here’s the main information:
 
-The GitHub handle or name of the community representative: [github username], email@somedomain.com \
-The date when the event will start: July 7, 2024 \
-The date when the event will end: July ​7, 2024 \
-What hours of the day will participants be active? 1:00pm - 5pm EEST (Athens, Greece). \
-Number of attendees: ~40 \
-Resources per user: 14.8GB RAM / up to 3.7 CPU \
-The URL of the hub that will be used for the event: <https://workshop.openscapes.2i2c.cloud/> \
-Access method: shared password \
-Password choice: [YouChooseAPassword]
+- The GitHub handle or name of the community representative: [github username], email@somedomain.com
+- The date when the event will start: July 7, 2024
+- The date when the event will end: July ​7, 2024
+- What hours of the day will participants be active? 1:00pm - 5pm EEST (Athens, Greece).
+- Number of attendees: ~40
+- Resources per user: 14.8GB RAM / up to 3.7 CPU
+- The URL of the hub that will be used for the event: <https://workshop.openscapes.2i2c.cloud/> (NASA) OR <https://workshop.nmfs-openscapes.2i2c.cloud/> (NMFS)
+- Access method: shared password
+- Password choice: [YouChooseAPassword]
 
 Thank you!
 
@@ -47,12 +53,22 @@ Erik
 :::
 
 Tell your learners that they will be able to access the Hub using the shared
-password for one week following the workshop, after which the password will
+password during and for one week following the workshop, after which the password will
 be changed and the their home directories inside the Hub will be removed.
 
-One week after the workshop, send another email to `support at 2i2c.freshdesk.com`
-and request that the password be reset and users' home directories from the
-workshop be removed.
+One week after the workshop, send another email to `support at 2i2c.freshdesk.com` 
+(again cc the hub's primarty contacts) and request that the password be reset 
+and users' home directories from the workshop be removed.
+
+### Instructions for Openscapes hub admins
+
+When the workshop request is made, record the new workshop password in the 
+[SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and 
+work with the workshop lead and 2i2c to ensure the hub will meet their needs
+and will be available when they need it.
+
+Seven days after the workshop finishes, coordinate with the workshop lead to 
+make a request to 2i2c to change the password. Record this change in the Google sheet.
 
 ## Workshop Hub Access via GitHub Teams
 

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -75,7 +75,7 @@ make a request to 2i2c to change the password. Record this change in the Google 
 
 ## Workshop Hub Access via GitHub Teams
 
-If you are hosting a workshop with where you will be teaching GitHub workflows, 
+If you are hosting a workshop where you will be teaching GitHub workflows, 
 and/or have learners who require longer-term access to the Hub after the workshop, 
 follow the instructions to [add participants to the 2i2c Hub](github-access.qmd#adding-champions-or-workshop-participants-to-the-hub-as-a-batch) 
 via a GitHub Team.

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -62,12 +62,15 @@ and users' home directories from the workshop be removed.
 
 ### Instructions for Openscapes hub admins
 
-When the workshop request is made, record the new workshop password in the 
+1. When the workshop request is made, record the new workshop password in the 
 [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and 
 work with the workshop lead and 2i2c to ensure the hub will meet their needs
 and will be available when they need it.
 
-Seven days after the workshop finishes, coordinate with the workshop lead to 
+2. Record the workshop in the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382). 
+Put "SinglePassword" in the `2i2c access type` column in the appropriate row.
+
+3. Seven days after the workshop finishes, coordinate with the workshop lead to 
 make a request to 2i2c to change the password. Record this change in the Google sheet.
 
 ## Workshop Hub Access via GitHub Teams


### PR DESCRIPTION
Update instructions for workshop leads and hub admins for setting up "shared-password" hub for workshops. Includes updating the workshop registry and a new process/sheet for managing the passwords for these hubs