### PR TITLE
Edits to shared-password process

### DIFF
--- a/password-access.qmd
+++ b/password-access.qmd
@@ -17,7 +17,7 @@ and participants, Hub admins do not have any way to contact the people added to
 the Hub. Thus, participants with this method are only allowed to stay in the Hub
 for one week before being removed.
 
-1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]) outling your workshop. 
+1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]) outlining your workshop. This is for awareness across the Mentor community, and to help you plan and be supported by the admin team.
 Also add it to the workshop registry ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and 
 put "SinglePassword" in the `2i2c access type` column. 
 If you don't have access to this sheet, reach out to the [primary contact/admin for your hub](about.qmd#primary-contacts).

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -17,8 +17,8 @@ and participants, Hub admins do not have any way to contact the people added to
 the Hub. Thus, participants with this method are only allowed to stay in the Hub
 for one week before being removed.
 
-1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NOAA [TBD]) outling your workshop. 
-Also add it to the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382), and 
+1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]) outling your workshop. 
+Also add it to the workshop registry ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and 
 put "SinglePassword" in the `2i2c access type` column. 
 If you don't have access to this sheet, reach out to the [primary contact/admin for your hub](about.qmd#primary-contacts).
 2. Check with the [primary contact/admin](about.qmd#primary-contacts) to ensure that the Hub image has the packages you need.
@@ -89,9 +89,9 @@ and users' home directories be removed *from the workshop hub*.
 *This section is for [Hub admins](about.qmd#primary-contacts) (Openscapes core team plus NASA/NOAA hub leads), who have access to the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and have close working relationships with 2i2c. 
 These steps intentionally align with the steps outlined above for workshop leads, and are meant to be collaborative - experienced mentors will be more familiar with the process and need less help than people leading workshops using the hub for the first time.*
 
-1. Work with workshop lead to open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NOAA [TBD]), and add it to the MainPlanning project board ([example](https://github.com/orgs/NASA-Openscapes/projects/7/views/1?pane=issue&itemId=93334218&issue=NASA-Openscapes%7Cworkshop-planning%7C137)).
+1. Work with workshop lead to open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]), and add it to the MainPlanning project board ([example](https://github.com/orgs/NASA-Openscapes/projects/7/views/1?pane=issue&itemId=93334218&issue=NASA-Openscapes%7Cworkshop-planning%7C137)).
 
-2. Record the workshop in the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should also have access to this sheet.
+2. Record the workshop in the workshop registry ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should also have access to this sheet.
 
 3. Help the workshop lead ensure that the resources in the hub are sufficient for the workshop's needs. 
 The default configuration should easily handle up to 100 particpants; more than that may require some work by 2i2c to scale up.

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -86,12 +86,12 @@ and users' home directories be removed *from the workshop hub*.
 
 ### Instructions for Openscapes hub admins
 
-*This section is for [Hub admins](about.qmd#primary-contacts), who have access to the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and have close working relationships with 2i2c. 
+*This section is for [Hub admins](about.qmd#primary-contacts) (Openscapes core team plus NASA/NOAA hub leads), who have access to the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and have close working relationships with 2i2c. 
 These steps intentionally align with the steps outlined above for workshop leads, and are meant to be collaborative - experienced mentors will be more familiar with the process and need less help than people leading workshops using the hub for the first time.*
 
 1. Work with workshop lead to open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NOAA [TBD]), and add it to the MainPlanning project board ([example](https://github.com/orgs/NASA-Openscapes/projects/7/views/1?pane=issue&itemId=93334218&issue=NASA-Openscapes%7Cworkshop-planning%7C137)).
 
-2. Record the workshop in the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should have access to this sheet.
+2. Record the workshop in the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should also have access to this sheet.
 
 3. Help the workshop lead ensure that the resources in the hub are sufficient for the workshop's needs. 
 The default configuration should easily handle up to 100 particpants; more than that may require some work by 2i2c to scale up.
@@ -100,4 +100,4 @@ The default configuration should easily handle up to 100 particpants; more than 
 
 5. Seven days after the workshop finishes, coordinate with the workshop lead to 
 make a request to 2i2c to change the password and remove user home directories
-from the *workshop hub* (definitely not the main hub). Record this change in the Google sheet.
+from the *workshop hub* (definitely not the main hub). Record the password change in the [Google sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0).

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -6,7 +6,7 @@ This page is written primarily for workshop leads (mentors and other partners) w
 
 ## Using the Openscapes 2i2c Hub in a workshop using a shared password
 
-### Instructions for workshop leads
+### Instructions for workshop leads / mentors
 
 If you are hosting a workshop that has a large number of participants, especially
 if workflows with GitHub are not part of the teaching curriculum, use the "shared password" 
@@ -17,19 +17,22 @@ and participants, Hub admins do not have any way to contact the people added to
 the Hub. Thus, participants with this method are only allowed to stay in the Hub
 for one week before being removed.
 
-- Check with the [primary contact/admin for your hub](about.qmd#primary-contacts) to 
-  ensure that the Hub image has the packages you need
-- Reach out to 2i2c _a month in advance_ via an email to `support at 2i2c.freshdesk.com` 
+1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NOAA [TBD]) outling your workshop. 
+Also add it to the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382), and 
+put "SinglePassword" in the `2i2c access type` column. 
+If you don't have access to this sheet, reach out to the [primary contact/admin for your hub](about.qmd#primary-contacts).
+2. Check with the [primary contact/admin](about.qmd#primary-contacts) to ensure that the Hub image has the packages you need.
+3. Reach out to 2i2c _a month in advance_ via an email to `support at 2i2c.freshdesk.com` 
   (example below), cc-ing the primary contacts for your hub, to tell them about the workshop date, start and end times, 
   \# of participants, and anticipated level of resources to be used. Also tell
   them that you would like to use the shared password hub, and provide a desired 
   password.
-- *Do not* ask your workshop particants to request access via the access request Google form - it is not necessary for these types of workshops.
+3. *Do not* ask your workshop particants to request access via the access request Google form - it is not necessary for these types of workshops.
 
 ::: {.callout-tip collapse="true"}
 ## Example email to 2i2c for a workshop with shared password authentication
 
-*To: support [at] 2i2c.freshdesk.com*
+*To: support [at] 2i2c.freshdesk.com* \
 *cc: Openscapes/NASA/NOAA [primary contact](about.qmd#primary-contacts)*
 
 Hello,
@@ -52,30 +55,49 @@ Thank you!
 Erik
 :::
 
-Tell your learners that they will be able to access the Hub using the shared
+Email your learners to tell them that they will be able to access the Hub using the shared
 password during and for one week following the workshop, after which the password will
 be changed and the their home directories inside the Hub will be removed.
 
+::: {.callout-tip collapse="true"}
+## Example email to workshop particpants for a workshop with shared password authentication
+
+*To: workshop participants*
+
+Hello!
+
+We are looking forward to hosting you for our upcoming workshop! We will do our
+work in the [NASA/NMFS]-Openscapes workshop hub:
+
+<https://workshop.openscapes.2i2c.cloud/> (NASA) OR <https://workshop.nmfs-openscapes.2i2c.cloud/> (NMFS)
+
+You will be provided a password at the beginning of the workshop which you can use to log in to the hub, along with your email address as your username. No prior setup is required. You will retain access to the hub, and the files you create within the hub, for one week after the workshop. After this the password will be reset and user directories will be removed.
+
+Thank you, looking forward to the workshop!
+
+Erik
+:::
+
+During the workshop, instruct participants to log in using their email address as their username, and the shared password.
+
 One week after the workshop, send another email to `support at 2i2c.freshdesk.com` 
 (again cc the hub's primarty contacts) and request that the password be reset 
-and users' home directories from the workshop be removed.
+and users' home directories be removed *from the workshop hub*.
 
 ### Instructions for Openscapes hub admins
 
-1. When the workshop request is made, record the new workshop password in the 
-[SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and 
-work with the workshop lead and 2i2c to ensure the hub will meet their needs
-and will be available when they need it.
+*This section is for [Hub admins](about.qmd#primary-contacts), who have access to the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and have close working relationships with 2i2c. 
+These steps intentionally align with the steps outlined above for workshop leads, and are meant to be collaborative - experienced mentors will be more familiar with the process and need less help than people leading workshops using the hub for the first time.*
 
-2. Record the workshop in the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382). 
-Put "SinglePassword" in the `2i2c access type` column in the appropriate row.
+1. Work with workshop lead to open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NOAA [TBD]), and add it to the MainPlanning project board ([example](https://github.com/orgs/NASA-Openscapes/projects/7/views/1?pane=issue&itemId=93334218&issue=NASA-Openscapes%7Cworkshop-planning%7C137)).
 
-3. Seven days after the workshop finishes, coordinate with the workshop lead to 
-make a request to 2i2c to change the password. Record this change in the Google sheet.
+2. Record the workshop in the [workshop registry](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should have access to this sheet.
 
-## Workshop Hub Access via GitHub Teams
+3. Help the workshop lead ensure that the resources in the hub are sufficient for the workshop's needs. 
+The default configuration should easily handle up to 100 particpants; more than that may require some work by 2i2c to scale up.
 
-If you are hosting a workshop where you will be teaching GitHub workflows, 
-and/or have learners who require longer-term access to the Hub after the workshop, 
-follow the instructions to [add participants to the 2i2c Hub](github-access.qmd#adding-champions-or-workshop-participants-to-the-hub-as-a-batch) 
-via a GitHub Team.
+4. Record the new workshop password in the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0).
+
+5. Seven days after the workshop finishes, coordinate with the workshop lead to 
+make a request to 2i2c to change the password and remove user home directories
+from the *workshop hub* (definitely not the main hub). Record this change in the Google sheet.

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -18,7 +18,7 @@ the Hub. Thus, participants with this method are only allowed to stay in the Hub
 for one week before being removed.
 
 1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]) outlining your workshop. This is for awareness across the Mentor community, and to help you plan and be supported by the admin team.
-Also add it to the workshop registry ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and 
+Also add your workshop to the **WorkshopRegistry** ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and 
 put "SinglePassword" in the `2i2c access type` column. 
 If you don't have access to this sheet, reach out to the [primary contact/admin for your hub](about.qmd#primary-contacts).
 2. Check with the [primary contact/admin](about.qmd#primary-contacts) to ensure that the Hub image has the packages you need.
@@ -89,9 +89,9 @@ and users' home directories be removed *from the workshop hub*.
 *This section is for [Hub admins](about.qmd#primary-contacts) (Openscapes core team plus NASA/NOAA hub leads), who have access to the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and have close working relationships with 2i2c. 
 These steps intentionally align with the steps outlined above for workshop leads, and are meant to be collaborative - experienced mentors will be more familiar with the process and need less help than people leading workshops using the hub for the first time.*
 
-1. Work with workshop lead to open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]), and add it to the MainPlanning project board ([example](https://github.com/orgs/NASA-Openscapes/projects/7/views/1?pane=issue&itemId=93334218&issue=NASA-Openscapes%7Cworkshop-planning%7C137)).
+1. Work with workshop lead in their issue (opening one if necessary) in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/NMFS [TBD]), and add it to the MainPlanning project board ([example](https://github.com/orgs/NASA-Openscapes/projects/7/views/1?pane=issue&itemId=93334218&issue=NASA-Openscapes%7Cworkshop-planning%7C137)).
 
-2. Record the workshop in the workshop registry ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should also have access to this sheet.
+2. Review and record the workshop in the **WorkshopRegistry** ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should also have access to this sheet.
 
 3. Help the workshop lead ensure that the resources in the hub are sufficient for the workshop's needs. 
 The default configuration should easily handle up to 100 particpants; more than that may require some work by 2i2c to scale up.


### PR DESCRIPTION
As discussed in coworking:

- Removed section on using GitHub based access
- Added sample email to workshop participants
- Add steps of opening `workshop-planning` issue and adding to workshop registry
- Align steps for workshop leads and hub leads, make them overlapping and collaborative
- Add note about hub capacity (i.e., up to 100 should be fine, over that may require some engineering work by 2i2c)

[Deploy preview for Password Access page](https://deploy-preview-20--openscapes-cloud-preview.netlify.app/password-access)