### PR TITLE
Workshop access instructions: Add information about new request and reporting issue templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 # Local Netlify folder
 .netlify
+
+**/*.quarto_ipynb

--- a/password-access.qmd
+++ b/password-access.qmd
@@ -17,17 +17,16 @@ and participants, Hub admins do not have any way to contact the people added to
 the Hub. Thus, participants with this method are only allowed to stay in the Hub
 for one week before being removed.
 
-1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/nasa-openscapes/workshop-planning/issues)/[NMFS](https://github.com/nmfs-openscapes/workshop-planning/issues)) outlining your workshop. This is for awareness across the Mentor community, and to help you plan and be supported by the admin team.
-Also add your workshop to the **WorkshopRegistry** ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and 
+1. Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/NASA-Openscapes/workshop-planning/issues/new/choose)/[NMFS](https://github.com/nmfs-openscapes/workshop-planning/issues/new/choose)) using the "Workshop request" template. This is for awareness across the Mentor community, and to help you plan and be supported by the admin team.
+2. Add your workshop to the **WorkshopRegistry** ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and 
 put "SinglePassword" in the `2i2c access type` column. 
 If you don't have access to this sheet, reach out to the [primary contact/admin for your hub](about.qmd#primary-contacts).
-2. Check with the [primary contact/admin](about.qmd#primary-contacts) to ensure that the Hub image has the packages you need.
 3. Reach out to 2i2c _a month in advance_ via an email to `support at 2i2c.freshdesk.com` 
   (example below), cc-ing the primary contacts for your hub, to tell them about the workshop date, start and end times, 
   \# of participants, and anticipated level of resources to be used. Also tell
   them that you would like to use the shared password hub, and provide a desired 
-  password.
-3. *Do not* ask your workshop particants to request access via the access request Google form - it is not necessary for these types of workshops.
+  password. Most of this information can be copied from the issue you opened in step 1.
+4. *Do not* ask your workshop participants to request access via the access request Google form - it is not necessary for these types of workshops.
 
 ::: {.callout-tip collapse="true"}
 ## Example email to 2i2c for a workshop with shared password authentication
@@ -64,7 +63,7 @@ directories inside the Hub will be removed.
 *Only provide the password to participants during the workshop.*
 
 ::: {.callout-tip collapse="true"}
-## Example email to workshop particpants for a workshop with shared password authentication
+## Example email to workshop participants for a workshop with shared password authentication
 
 *To: workshop participants*
 
@@ -84,11 +83,15 @@ Erik
 
 During the workshop, instruct participants to log in using their email address as their username, and the shared password.
 
+### After the workshop
+
+Open an issue in the appropriate `workshop-planning` repository ([NASA](https://github.com/NASA-Openscapes/workshop-planning/issues/new/choose)/[NMFS](https://github.com/nmfs-openscapes/workshop-planning/issues/new/choose)) using the "Workshop reporting" issue template. This is used to highlight successes and lessons from the workshop, and can be used to craft a short blog post to share with the broader community.
+
 One week after the workshop, send another email to `support at 2i2c.freshdesk.com` 
-(again cc the hub's primarty contacts) and request that the password be reset 
+(again cc the hub's primary contacts) and request that the password be reset 
 and users' home directories be removed *from the workshop hub*.
 
-### Instructions for Openscapes hub admins
+## Instructions for Openscapes hub admins
 
 *This section is for [Hub admins](about.qmd#primary-contacts) (Openscapes core team plus NASA/NOAA hub leads), who have access to the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0), and have close working relationships with 2i2c. 
 These steps intentionally align with the steps outlined above for workshop leads, and are meant to be collaborative - experienced mentors will be more familiar with the process and need less help than people leading workshops using the hub for the first time.*
@@ -98,7 +101,7 @@ These steps intentionally align with the steps outlined above for workshop leads
 2. Review and record the workshop in the **WorkshopRegistry** ([NASA](https://docs.google.com/spreadsheets/d/1Sg4fMDGxMLI0p5cgK5xyamFJpKC6NyNneqXLDReSKcg/edit#gid=695033382)/[NMFS](https://docs.google.com/spreadsheets/d/14GDUFU3_H2bZcSt--VGLRmrRFq3dylDL8ZeAKuFbV6E/edit?gid=695033382#gid=695033382)), and put "SinglePassword" in the `2i2c access type` column in the appropriate row. All mentors should also have access to this sheet.
 
 3. Help the workshop lead ensure that the resources in the hub are sufficient for the workshop's needs. 
-The default configuration should easily handle up to 100 particpants; more than that may require some work by 2i2c to scale up.
+The default configuration should easily handle up to 100 participants; more than that may require some work by 2i2c to scale up.
 
 4. Record the new workshop password in the [SharedPasswords-Openscapes.Cloud Google Sheet](https://docs.google.com/spreadsheets/d/1Y4qzqWLsKHTNzuQi-fOaHGud0Ld_q1GHAzhS9-grV7Q/edit?gid=0#gid=0).
 


### PR DESCRIPTION
To bring the instructions up to par with [the changes we made in NASA-Openscapes/workshop-planning](https://github.com/NASA-Openscapes/workshop-planning/pull/168)